### PR TITLE
Fix Typo in `eth-mainnet.json`

### DIFF
--- a/configs/marketplace/eth-mainnet.json
+++ b/configs/marketplace/eth-mainnet.json
@@ -198,7 +198,7 @@
     "internalWallet": false
   },
   {
-    "author": "Frax Finanace",
+    "author": "Frax Finance",
     "id": "frax-finance",
     "title": "Frax Finance",
     "description": "Fraxswap is the first constant product automated market maker with an embedded time-weighted average market maker (TWAMM) for conducting large trades over long periods of time trustlessly. It is fully permissionless and the core AMM is based on Uniswap V2.",


### PR DESCRIPTION
# Pull Request: Fix Typo in `eth-mainnet.json`

## Description
This pull request corrects a typo in the `eth-mainnet.json` file. The author "Frax Finanace" was corrected to "Frax Finance".

- **Before**: `"author": "Frax Finanace"`
- **After**: `"author": "Frax Finance"`

This change ensures the accuracy of the author name in the configuration.

## References (if applicable)
- N/A (If applicable, link to related issues or discussions here)

## Checklist
- [x] Code follows the repository’s coding conventions
- [x] Changes are described in the PR
- [ ] Tests have been added/updated (if applicable)
- [ ] Documentation has been updated (if necessary)
