### PR TITLE
fix: update Twitter URL to x.com format

### DIFF
--- a/configs/footer-links/astar.json
+++ b/configs/footer-links/astar.json
@@ -34,7 +34,7 @@
 		"title": "Community",
 		"links": [{
 				"text": "Twitter",
-				"url": "https://twitter.com/astarNetwork"
+				"url": "https://x.com/astarNetwork"
 			},
 			{
 				"text": "Discord",

--- a/configs/footer-links/base-goerli.json
+++ b/configs/footer-links/base-goerli.json
@@ -17,7 +17,7 @@
     "links": [
       {
         "text": "Twitter",
-        "url": "https://twitter.com/buildonbase"
+        "url": "https://x.com/buildonbase"
       },
       {
         "text": "Discord",

--- a/configs/footer-links/base-mainnet.json
+++ b/configs/footer-links/base-mainnet.json
@@ -17,7 +17,7 @@
     "links": [
       {
         "text": "Twitter",
-        "url": "https://twitter.com/buildonbase"
+        "url": "https://x.com/buildonbase"
       },
       {
         "text": "Discord",

--- a/configs/footer-links/base-sepolia.json
+++ b/configs/footer-links/base-sepolia.json
@@ -17,7 +17,7 @@
     "links": [
       {
         "text": "Twitter",
-        "url": "https://twitter.com/buildonbase"
+        "url": "https://x.com/buildonbase"
       },
       {
         "text": "Discord",

--- a/configs/footer-links/fvm.json
+++ b/configs/footer-links/fvm.json
@@ -10,7 +10,7 @@
 			},
 			{
 				"text": "Twitter",
-				"url": "https://twitter.com/Filecoin"
+				"url": "https://x.com/Filecoin"
 			},
 			{
 				"text": "Forum",

--- a/configs/footer-links/immutable.json
+++ b/configs/footer-links/immutable.json
@@ -46,7 +46,7 @@
       },
       {
         "text": "Twitter",
-        "url": "https://twitter.com/Immutable"
+        "url": "https://x.com/Immutable"
       },
       {
         "text": "Reddit",

--- a/configs/footer-links/iota-evm-testnet.json
+++ b/configs/footer-links/iota-evm-testnet.json
@@ -46,7 +46,7 @@
 		"title": "Connect",
 		"links": [{
 				"text": "Twitter",
-				"url": "https://twitter.com/iota"
+				"url": "https://x.com/iota"
 			},
 			{
 				"text": "Discord",

--- a/configs/footer-links/iota-evm.json
+++ b/configs/footer-links/iota-evm.json
@@ -54,7 +54,7 @@
 		"links": [
 			{
 				"text": "Twitter",
-				"url": "https://twitter.com/iota"
+				"url": "https://x.com/iota"
 			},
 			{
 				"text": "Discord",

--- a/configs/footer-links/iota-shimmer.json
+++ b/configs/footer-links/iota-shimmer.json
@@ -42,7 +42,7 @@
 		"title": "Connect",
 		"links": [{
 				"text": "Twitter",
-				"url": "https://twitter.com/shimmernet"
+				"url": "https://x.com/shimmernet"
 			},
 			{
 				"text": "Discord",

--- a/configs/footer-links/optimism.json
+++ b/configs/footer-links/optimism.json
@@ -66,7 +66,7 @@
 			},
 			{
 				"text": "Twitter",
-				"url": "https://twitter.com/optimismFND"
+				"url": "https://x.com/optimismFND"
 			},
 			{
 				"text": "Twitch",

--- a/configs/footer-links/redstone.json
+++ b/configs/footer-links/redstone.json
@@ -46,7 +46,7 @@
 			},
 			{
 				"text": "X (ex-Twitter)",
-				"url": "https://twitter.com/redstonexyz"
+				"url": "https://x.com/redstonexyz"
 			}
 		]
 	},

--- a/configs/footer-links/rootstock.json
+++ b/configs/footer-links/rootstock.json
@@ -62,7 +62,7 @@
       },
       {
         "text": "Twitter",
-        "url": "https://twitter.com/rootstock_io"
+        "url": "https://x.com/rootstock_io"
       },
       {
         "text": "Telegram",

--- a/configs/footer-links/shibuya.json
+++ b/configs/footer-links/shibuya.json
@@ -34,7 +34,7 @@
 		"title": "Community",
 		"links": [{
 				"text": "Twitter",
-				"url": "https://twitter.com/astarNetwork"
+				"url": "https://x.com/astarNetwork"
 			},
 			{
 				"text": "Discord",

--- a/configs/footer-links/shiden.json
+++ b/configs/footer-links/shiden.json
@@ -34,7 +34,7 @@
 		"title": "Community",
 		"links": [{
 				"text": "Twitter",
-				"url": "https://twitter.com/ShidenNetwork"
+				"url": "https://x.com/ShidenNetwork"
 			},
 			{
 				"text": "Discord",

--- a/configs/footer-links/zksync.json
+++ b/configs/footer-links/zksync.json
@@ -54,7 +54,7 @@
             },
             {
                 "text": "Twitter",
-                "url": "https://twitter.com/zksync"
+                "url": "https://x.com/zksync"
             },
             {
                 "text": "Blog",

--- a/configs/marketplace/eth-goerli.json
+++ b/configs/marketplace/eth-goerli.json
@@ -132,7 +132,7 @@
 		"description": "zkBob simplifies secure, limited-value, and anonymous token transfers for everyday users. The application accepts WETH, ETH, USDC. Once one of the tokens is deposited in the zkBob app, pool participants can transfer tokens amongst themselves in a private, secure manner. The shielded zkBob pool uses zkproofs to limit public data exposure",
 		"external": false,
 		"url": "https://staging--zkbob.netlify.app/transfer",
-		"twitter": "https://twitter.com/zkBob_",
+		"twitter": "https://x.com/zkBob_",
 		"telegram": "https://t.me/zkbobcommunity",
 		"internalWallet": false
 	},

--- a/configs/marketplace/optimism.json
+++ b/configs/marketplace/optimism.json
@@ -210,7 +210,7 @@
     "description": "zkBob simplifies secure, limited-value, and anonymous token transfers for everyday users. The application accepts WETH, ETH, USDC. Once one of the tokens is deposited in the zkBob app, pool participants can transfer tokens amongst themselves in a private, secure manner. The shielded zkBob pool uses zkproofs to limit public data exposure",
     "external": false,
     "url": "https://zkbob-ui-qn7wq2.dappling.eth.limo/#/?pool=BOB2USDC-optimism",
-    "twitter": "https://twitter.com/zkBob_",
+    "twitter": "https://x.com/zkBob_",
     "telegram": "https://t.me/zkbobcommunity",
     "internalWallet": false
   },


### PR DESCRIPTION
Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.